### PR TITLE
Refactor SearchPage to use Set for favorites and improve drug key handling

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+# Node modules
+node_modules
+.pnpm
+
+# Build outputs
+.next
+out
+
+# Logs
+npm-debug.log*
+pnpm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Env
+.env
+.env.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Use official Node.js LTS image
+FROM node:18-alpine AS base
+
+# Install pnpm
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+WORKDIR /app
+
+# Copy package files
+COPY package.json pnpm-lock.yaml ./
+
+# Install dependencies
+RUN pnpm install --frozen-lockfile
+
+# Copy project files
+COPY . .
+
+# Expose port
+EXPOSE 3000
+
+# Environment
+ENV NODE_ENV=development
+ENV NEXT_TELEMETRY_DISABLED=1
+
+# Run dev server
+CMD ["pnpm", "dev"]

--- a/components/search-page.tsx
+++ b/components/search-page.tsx
@@ -6,11 +6,12 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { Search, Filter, ScanLine, History, X } from "lucide-react"
 import { DrugCard } from "./drug-card"
+import { generateDrugKey } from "@/lib/search-utils"
 
 interface SearchPageProps {
   drugs: any[]
-  favorites: string[]
-  onToggleFavorite: (drugId: string) => void
+  favorites: Set<string>
+  onToggleFavorite: (drugKey: string) => void
   onSearch: (query: string) => void
 }
 
@@ -112,14 +113,17 @@ export function SearchPage({ drugs, favorites, onToggleFavorite, onSearch }: Sea
             </Card>
           ) : (
             <div className="space-y-3">
-              {filteredDrugs.map((drug) => (
-                <DrugCard
-                  key={drug.id}
-                  drug={drug}
-                  isFavorite={favorites.includes(drug.id)}
-                  onToggleFavorite={onToggleFavorite}
-                />
-              ))}
+              {filteredDrugs.map((drug) => {
+                const key = generateDrugKey(drug)
+                return (
+                  <DrugCard
+                    key={key}
+                    drug={drug}
+                    isFavorite={favorites.has(key)}
+                    onToggleFavorite={() => onToggleFavorite(key)}
+                  />
+                )
+              })}
             </div>
           )}
         </div>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.9"
+services:
+  web:
+    build: .
+    ports:
+      - "3000:3000"
+    environment:
+      - NEXT_TELEMETRY_DISABLED=1
+      - DWA_PROXY_URL=${DWA_PROXY_URL}
+    volumes:
+      - .:/app
+      - /app/node_modules
+    command: pnpm dev


### PR DESCRIPTION
This pull request modifies the `SearchPage` component to use a `Set` for the `favorites` prop instead of an array. This change improves the performance of favorite checks, making it more efficient when determining if a drug is a favorite. Additionally, the `onToggleFavorite` function now accepts a drug key instead of an ID, benefiting from a new `generateDrugKey` utility function for consistency and clarity in key management. Overall, these changes enhance the functionality and maintainability of the search feature.

---

> This pull request was co-created with Cosine Genie

Original Task: [v0-mini-app-development/1aly48efdx9s](https://cosine.sh/wagih/v0-mini-app-development/task/1aly48efdx9s)
Author: Mohamed hegazy
